### PR TITLE
fix link to species.csv file

### DIFF
--- a/06-data-formats-caveats.md
+++ b/06-data-formats-caveats.md
@@ -29,7 +29,7 @@ The value for 'taxa' was split into two columns (instead of being put in one col
 
 ### Dealing with commas as part of data values in `*.csv` files
 
-If you want to store your data in `*.csv` and expect that your data may contain commas in their values, you can avoid the problem discussed above by putting the values in quotes (""). This [example data file](./spreadsheet-ecology-lesson/data/biology/species.csv) applies this rule so the actual data looks like:
+If you want to store your data in `*.csv` and expect that your data may contain commas in their values, you can avoid the problem discussed above by putting the values in quotes (""). This [example data file](./data/biology/species.csv) applies this rule so the actual data looks like:
 
 	species_id,genus,species,taxa
 	"AB","Amphispiza","bilineata","Bird"
@@ -47,7 +47,7 @@ This original file does not contain commas in the values.
 
 But let's see what would happen if we introduced a comma into  `"Rodent-not censused"` - so that it looks like this: `"Rodent-not, censused"`. 
 
-1. Open the [species.csv](./spreadsheet-ecology-lesson/data/biology/species.csv) file in Excel (or Calc in Libre Office).
+1. Open the [species.csv](./data/biology/species.csv) file in Excel (or Calc in Libre Office).
 2. Add the comma (,) in `"Rodent-not censused"`.
 3. Save the file under a **different name** (but also in the `csv` format) and reopen it in Excel.
 4. The issue with the "extra" incorrect column should not appear.

--- a/06-data-formats-caveats.md
+++ b/06-data-formats-caveats.md
@@ -29,7 +29,7 @@ The value for 'taxa' was split into two columns (instead of being put in one col
 
 ### Dealing with commas as part of data values in `*.csv` files
 
-If you want to store your data in `*.csv` and expect that your data may contain commas in their values, you can avoid the problem discussed above by putting the values in quotes (""). This [example data file](../../../data/biology/species.csv) applies this rule so the actual data looks like:
+If you want to store your data in `*.csv` and expect that your data may contain commas in their values, you can avoid the problem discussed above by putting the values in quotes (""). This [example data file](./spreadsheet-ecology-lesson/data/biology/species.csv) applies this rule so the actual data looks like:
 
 	species_id,genus,species,taxa
 	"AB","Amphispiza","bilineata","Bird"
@@ -47,7 +47,7 @@ This original file does not contain commas in the values.
 
 But let's see what would happen if we introduced a comma into  `"Rodent-not censused"` - so that it looks like this: `"Rodent-not, censused"`. 
 
-1. Open the [species.csv](../../../data/biology/species.csv) file in Excel (or Calc in Libre Office).
+1. Open the [species.csv](./spreadsheet-ecology-lesson/data/biology/species.csv) file in Excel (or Calc in Libre Office).
 2. Add the comma (,) in `"Rodent-not censused"`.
 3. Save the file under a **different name** (but also in the `csv` format) and reopen it in Excel.
 4. The issue with the "extra" incorrect column should not appear.


### PR DESCRIPTION
The link to `species.csv` in the [data formats lesson](http://datacarpentry.github.io/spreadsheet-ecology-lesson/06-data-formats-caveats.html) is broken. I think this pull request should fix this - worked at least on my forked repo.