### PR TITLE
Added sentence and modified example on units in field names.

### DIFF
--- a/02-common-mistakes.md
+++ b/02-common-mistakes.md
@@ -110,13 +110,13 @@ From White et al, 2013, [Nine simple ways to make it easier to (re)use your data
 
 ## <a name="field_name"></a> Field name problems
 Choose descriptive field names, but be careful not to include: spaces, numbers, or special characters of any kind. Spaces can be misinterpreted by parsers that use whitespace as delimiters and some programs don’t like field names that are text strings that start with numbers.
-Underscores (`_`) are a good alternative to spaces and consider writing names in camel-case to improve readability. Remember that abbreviations that make sense at the moment may not be so obvious in 6 months but don't overdo it with names that are eccessivly long.
+Underscores (`_`) are a good alternative to spaces and consider writing names in camel-case to improve readability. Remember that abbreviations that make sense at the moment may not be so obvious in 6 months but don't overdo it with names that are eccessivly long. Including the units in the field names avoids confusion and enables others to readily interpret your fields.
 
 **Examples**  
 
 **good name** | **good alternative** | **avoid**
 ------------- | -------------------- | ---------
-Max_temp     | MaxTemp              | Maximum Temp (°C)
+Max_temp_C    | MaxTemp              | Maximum Temp (°C)
 Precipitation | Precipitation_mm | precmm
 Mean_year_growth | MeanYearGrowth | Mean growth/year
 sex | sex | M/F


### PR DESCRIPTION
We should encourage the use of units in field names.

Confusion about what units are used for a field can lead to
inaccurate results and 100s of millions of dollars mistake, e.g.
https://en.wikipedia.org/wiki/Mars_Climate_Orbiter

Citing this example during instruction may be useful.
