### PR TITLE
Special Characters heading

### DIFF
--- a/02-common-mistakes.md
+++ b/02-common-mistakes.md
@@ -159,6 +159,7 @@ Underscores (`_`) are a good alternative to spaces and consider writing names in
 	<td> 1st Obs</td>
 </tr>
 </table>
+<p><br><br><br><br><br><br><br><br><br><br />
 
 ## <a name="special"></a> Special characters in data
 


### PR DESCRIPTION
added a few line breaks to ensure the Special Characters heading displays underneath the table and not next to it.