### PR TITLE
Update Code of Conduct URL, closes #93

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -46,7 +46,7 @@
       <ul class="nav navbar-nav">
 
 	{% comment %} Always show code of conduct. {% endcomment %}
-        <li><a href="{{ page.root }}/conduct/">Code of Conduct</a></li>
+        <li><a href="{{ site.dc_site }}/code-of-conduct/">Code of Conduct</a></li>
 
 	{% comment %} Show setup instructions, reference guide, and lesson episodes for lessons. {% endcomment %}
         {% if site.kind == "lesson" %}


### PR DESCRIPTION
Now it goes to http://www.datacarpentry.org/code-of-conduct/, rather than the lesson-specific CoC

