### PR TITLE
Remove contributors

### DIFF
--- a/_episodes/00-intro.md
+++ b/_episodes/00-intro.md
@@ -10,9 +10,7 @@ keypoints:
 - "Good data organization is the foundation of any research project."
 ---
 
-Authors:**Christie Bahlai**, **Aleksandra Pawlik**<br>
-Contributors: **Jennifer Bryan**, **Alexander Duryee**, **Jeffrey Hollister**, **Daisie Huang**, **Owen Jones**, **Clare Sloggett**, **Harriet Dashnow** and
-**Ben Marwick**
+Authors:**Christie Bahlai**, **Aleksandra Pawlik**<br>  
 
 Good data organization is the foundation of your research
 project. Most researchers have data or do data entry in

--- a/_episodes/01-format-data.md
+++ b/_episodes/01-format-data.md
@@ -14,8 +14,6 @@ keypoints:
 ---
 
 Authors: **Christie Bahlai**, **Aleksandra Pawlik**<br>
-Contributors: **Jennifer Bryan**, **Alexander Duryee**, **Jeffrey Hollister**, **Daisie Huang**, **Owen Jones**, 
-**Ben Marwick** and **Sebastian Kupny**.
 
 The most common mistake made is treating treating spreadsheet programs like lab notebooks, that is, 
 relying on context, notes in the margin,

--- a/_episodes/02-common-mistakes.md
+++ b/_episodes/02-common-mistakes.md
@@ -21,7 +21,6 @@ keypoints:
 ---
 
 Authors:**Christie Bahlai**, **Aleksandra Pawlik**<br>
-Contributors: **Jennifer Bryan**, **Alexander Duryee**, **Jeffrey Hollister**, **Daisie Huang**, **Owen Jones**, and **Ben Marwick**
 
 ## Common Spreadsheet Errors
 

--- a/_episodes/03-dates-as-data.md
+++ b/_episodes/03-dates-as-data.md
@@ -13,8 +13,6 @@ keypoints:
 ---
 
 Authors:**Christie Bahlai**, **Aleksandra Pawlik**<br>
-Contributors: **Jennifer Bryan**, **Angel Corpuz**, **Alexander Duryee**,
-**Jeffrey Hollister**, **Daisie Huang**, **Owen Jones**, and **Ben Marwick**
 
 Dates in spreadsheets are stored in a single column. While this seems the
 most natural way to record dates, it actually is not best

--- a/_episodes/04-quality-control.md
+++ b/_episodes/04-quality-control.md
@@ -14,8 +14,6 @@ keypoints:
 ---
 
 Authors:**Christie Bahlai**, **Aleksandra Pawlik**<br>
-Contributors: **Jennifer Bryan**, **Alexander Duryee**, **Jeffrey Hollister**, **Daisie Huang**, **Owen Jones**,
-**Ben Marwick**, and **Ethan White**
 
 When you have a well-structured data table, you can use several simple
 techniques within your spreadsheet to ensure the data you enter is

--- a/_episodes/05-exporting-data.md
+++ b/_episodes/05-exporting-data.md
@@ -13,8 +13,6 @@ keypoints:
 ---
 
 Authors:**Christie Bahlai**, **Aleksandra Pawlik**<br>
-Contributors: **Jennifer Bryan**, **Alexander Duryee**, **Jeffrey Hollister**, **Daisie Huang**, **Owen Jones**, and
-**Ben Marwick**
 
 Storing the data you're going to work with for your analyses in Excel
 default file format (`*.xls` or `*.xlsx` - depending on the Excel


### PR DESCRIPTION
The original lesson files explicitly list authors and contributors, however, there have been many contributors since then. Listing all contributors on the lesson page is not scalable. All contributors will be listed as authors in the lesson release although ordering hasn't yet been decided. For SWC, the list is alphabetical with maintainers shown as editors. I propose that authors be listed in order of number of contributions (either number of commits or number of lines added), with maintainers shown as editors. @tracykteal @cbahlai @ethanwhite @apawlik thoughts?