### PR TITLE
added note about text being formatted as dates

### DIFF
--- a/_episodes/03-dates-as-data.md
+++ b/_episodes/03-dates-as-data.md
@@ -26,6 +26,9 @@ Gnumeric, etc.) are usually guaranteed to be compatible only within the same
 family of products. If you will later need to export the data and need to
 conserve the timestamps, you are better off handling them using one of the solutions discussed below.  
 
+Additionally, Excel can [turn things that aren't dates into dates](https://nsaunders.wordpress.com/2012/10/22/gene-name-errors-and-excel-lessons-not-learned/), 
+for example names or identifiers like MAR1, DEC1, OCT4. So if you're avoiding the date format overall, it's easier to identify these issues. 
+
 > ## Exercise 
 >
 > Challenge: pulling month, day and year out of dates 


### PR DESCRIPTION
Addresses https://github.com/datacarpentry/spreadsheet-ecology-lesson/issues/5, adding the information that spreadsheet programs can mis-interpret text as dates.