### PR TITLE
prevent jekyll-cache transfers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ _site
 .Rproj.user
 .Rhistory
 .RData
+.jekyll-cache
 

--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,7 @@ exclude:
   - Makefile
   - bin/
   - .Rproj.user/
+  - .jekyll-cache/
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge


### PR DESCRIPTION
This changes the _config.yml and the .gitignore files to prevent a jekyll-cache folder from being uploaded. This does not appear to affect the page rendering. @tracykteal @fmichonneau please review.