### PR TITLE
Explained how data with year 2015 showed up in the dataset - fixes 291.

### DIFF
--- a/_episodes/01-format-data.md
+++ b/_episodes/01-format-data.md
@@ -119,10 +119,11 @@ So, instead we should have:
 > 1. Download the data by clicking [here](https://ndownloader.figshare.com/files/2252083) to get it from FigShare.
 > 2. Open up the data in a spreadsheet program. 
 > 3. You can see that there are two tabs. Two field assistants conducted the surveys, one
-in 2013 and one in 2014, and they both kept track of the data in their own way. Now
+in 2013 and one in 2014, and they both kept track of the data in their own way in tabs `2013` and `2014` of the dataset, 
+>respectively. Now
 you're the person in charge of this project and you want to be able to 
 start analyzing the data.   
-> 4. With the person next to you, identify what is wrong with this spreadsheet. Also discuss the steps you would need to take to clean up the 2013 and 2014 tabs, and to put them all together in one spreadsheet. 
+> 4. With the person next to you, identify what is wrong with this spreadsheet. Also discuss the steps you would need to take to clean up the `2013` and `2014` tabs, and to put them all together in one spreadsheet. 
 >
 > **Important** Do not forget our first piece of advice: to
 > create a new file (or tab) for the cleaned data, never
@@ -136,8 +137,15 @@ start analyzing the data.
 > > - All the mistakes in [02-common-mistakes](../02-common-mistakes) are present in the messy dataset. If the
 > > exercise is done during a workshop, ask people what they saw as wrong with
 > > the data. As they bring up different points, you can refer to [02-common-mistakes](../02-common-mistakes)
-> > or expand a bit on the point they brought up.
-> > - If you get a response where they've fixed the date, you can pause and go to the [03-dates-as-data](../03-dates-as-data) lesson. Or you can say you'll come back to dates at the end. 
+> > or expand a bit on the point they brought up.  
+> > - Note that there is a problem with dates in table 'plot 3' in `2014` tab. The field assistant who collected the data
+> > for year 2014 initially forgot to include their data for 'plot 3'. They came back in 2015 to include the missing data and 
+> > entered the dates for 'plot 3' in the dataset without the year. Excel automatically filled in the missing year as the
+> > current year (i.e. 2015) - introducing an error in the data without the field assistant realising. If you get a response 
+> > from the participants that they've spotted and fixed the problem with date, you can say you'll come back to dates again 
+> > towards the end of lesson in episode [03-dates-as-data](../03-dates-as-data). If participants have not spotted the 
+> > problem with dates in 'plot 3' table, that's fine as you will address peculiarities of working with dates in 
+> > spreadsheets in episode [03-dates-as-data](../03-dates-as-data).  
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/03-dates-as-data.md
+++ b/_episodes/03-dates-as-data.md
@@ -30,20 +30,20 @@ for example names or identifiers like MAR1, DEC1, OCT4. So if you're avoiding th
 > ## Exercise 
 >
 > Challenge: pulling month, day and year out of dates 
+>   
+> - Let's create a tab called `dates` in our data spreadsheet and copy the 'plot 3' table from the `2014` tab (that contains the problematic dates). 
+> - Let’s extract month, day and year from the dates in the `Date collected` column into new columns. For this we 
+> can use the following built-in Excel functions:
 >
-> - In the `dates` tab of your spreadsheet you have the data from 2014 plot 3. 
-> There's a `Date collected` column.
-> - Let’s extract month, day and year from the dates to new columns. For this we 
-> can use the built in Excel functions
+> `YEAR()`  
 >
-> `YEAR()`
-> `MONTH()`    
-> `DAY()`  
+> `MONTH()`             
+>
+> `DAY()`
 > 
-> (Make sure the new column is formatted as a number and not as a date.)
+> (Make sure the new columns are formatted as a number and not as a date.)
 >
-> You can see that even though you wanted the year to be 2014, your spreadsheet program
-> automatically interpreted it as 2015, the year you entered the data.
+> You can see that even though we expected the year to be 2014, the year is actually 2015. What happened here is that the field assistant who collected the data for year 2014 initially forgot to include their data for 'plot 3' in this dataset. They came back in 2015 to add the missing data into the dataset and entered the dates for 'plot 3' without the year. Excel automatically interpreted the year as 2015 - the year the data was entered into the spreadsheet and not the year the data was collected. Thereby, the spreadsheet program introduced an error in the dataset without the field assistant realising.
 >
 > > ## Solution
 > > ![dates, exersize 1](../fig/solution_exercise_1_dates.png)
@@ -130,17 +130,18 @@ the quantities to the correct entities.
 
 Which brings us to the many different ways Excel provides in how it displays dates. If you refer to the figure above, you’ll see that
 there are many ways that ambiguity creeps into your data depending on the format you chose when you enter your data, and if you’re not
-fully aware of which format you’re using, you can end up actually entering your data in a way that Excel will badly misinterpret. 
+fully aware of which format you’re using, you can end up actually entering your data in a way that Excel will badly misinterpret and 
+you will end up with errors in your data that will be extremely difficult to track down and troubleshoot. 
 
 > ## Exercise  
-> What happens to the dates in the "dates" tab of our workbook if we save this sheet in Excel (in `csv` format) and then open the file in a plain text editor (like TextEdit or Notepad)? What happens to the dates if we then open the `csv` file in Excel?
+> What happens to the dates in the `dates` tab of our workbook if we save this sheet in Excel (in `csv` format) and then open the file in a plain text editor (like TextEdit or Notepad)? What happens to the dates if we then open the `csv` file in Excel?
 > > ## Solution
-> > - Click to the "dates" tab of the workbook and double-click on any of the values in the `Date collected` column. Notice that the dates display with the year 2015.   
+> > - Click to the `dates` tab of the workbook and double-click on any of the values in the `Date collected` column. Notice that the dates display with the year 2015.   
 > > - Select `File -> Save As` in Excel and in the drop down menu for file format select `CSV UTF-8 (Comma delimited) (.csv)`. Click `Save`.  
 > > - You will see a pop-up that says "This workbook cannot be saved in the selected file format because it contains multiple sheets." Choose `Save Active Sheet`.   
 > > - Navigate to the file in your finder application. Right click and select `Open With`. Choose a plain text editor application and view the file. Notice that the dates display as month/day without any year information.   
 > > - Now right click on the file again and open with Excel. Notice that the dates display with the current year, not 2015.   
-> > As you can see, exporting data from Excel and then importing it back into Excel fundamentally changed the data!  
+> > As you can see, exporting data from Excel and then importing it back into Excel fundamentally changed the data once again!  
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
Fix for https://github.com/datacarpentry/spreadsheet-ecology-lesson/issues/291. I tried to explain a bit better where the error with dates in 'plot' 3 in tab '2014' of the dataset is coming from. I also propose to remove tab 'dates' from the dataset and create is as part of the exercise in episode 03 about dates. However, the dataset is located in FigShare and I cannot modify it. even if tab 'dates' remain in the dataset, I believe this proposed PR is valid and instructors can explain what was done on that tab and how it was created (i.e. by copying 'plot 3' table from tab '2014').