### PR TITLE
Update 03-dates-as-data.md

### DIFF
--- a/_episodes/03-dates-as-data.md
+++ b/_episodes/03-dates-as-data.md
@@ -182,8 +182,10 @@ So, can you convert all your dates into DOY format? Well, in Excel, here’s a u
 ### <a name="str"></a> Storing dates as a single string
 
 Another alternative could be to convert the date string
-into a single string using the `YYYYMMDDhhmmss` format.
-For example the date `March 24, 2015 17:25:35` would
+into a single string using the `YYYYMMDD` format.
+For example the date `March 24, 2015` would become `20150324`.
+This option also works for datetimes using the `YYYYMMDDhhmmss` format.
+So the datetime `March 24, 2015 17:25:35` would
 become `20150324172535`, where:
 
 


### PR DESCRIPTION
I added YYYYMMDD as the primary option under the "Storing dates as a single string" heading, which I've found to be more generally useful than the full datetime YYYYMMDDhhmmss format. The datetime example is still there, but secondary.
